### PR TITLE
Handle when it fails to call API

### DIFF
--- a/lib/money/bank/wego_money_bank.rb
+++ b/lib/money/bank/wego_money_bank.rb
@@ -47,7 +47,9 @@ class Money
       end
 
       def fetch_from_url
-        open(url).read
+        open(url, read_timeout: 3).read
+      rescue OpenURI::HTTPError
+        nil
       end
 
       def fetch_from_cache
@@ -55,7 +57,7 @@ class Money
       end
 
       def exchange_rates
-        JSON.parse(fetch)
+        fetch.nil? ? [] : JSON.parse(fetch)
       end
 
       def get_rate(from, to)
@@ -106,7 +108,7 @@ class Money
 
       def refresh_rates_cache
         json_rates = fetch_from_url
-        if cache
+        if cache && json_rates
           open(cache, 'w') do |f|
             f.write(json_rates)
           end

--- a/spec/lib/wego/money/bank/wego_money_bank_spec.rb
+++ b/spec/lib/wego/money/bank/wego_money_bank_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Money::Bank::WegoMoneyBank do
     it ('return an array of exchange_rates') do
       expect(subject.exchange_rates.size).to eq(4)
     end
+
+    context 'no rates from cache and API' do
+      it 'returns empty array' do
+        allow(subject).to receive(:fetch_from_cache).and_return nil
+        allow(subject).to receive(:fetch_from_url).and_return nil
+        expect(subject.exchange_rates).to be_empty
+      end
+    end
   end
 
   describe '#update_rates' do
@@ -93,6 +101,19 @@ RSpec.describe Money::Bank::WegoMoneyBank do
       expect(rates[1]['code']).to eq('AED')
       expect(rates[2]['code']).to eq('PHP')
       expect(rates[3]['code']).to eq('VND')
+    end
+  end
+
+  describe '#fetch_from_url' do
+
+    context 'request is more than 3 seconds' do
+      let(:error) { OpenURI::HTTPError.new('504 Gateway Timeout', nil) }
+      before do
+        WebMock.stub_request(:get, Money::Bank::WegoMoneyBank::API_URL).to_raise error
+      end
+      it 'returns nil' do
+        expect(subject.fetch_from_url).to eq nil
+      end
     end
   end
 


### PR DESCRIPTION
every now and then, this gem would update latest `exchange_rates.json` by fetching from API. but sometimes, API returns error. In this case, just reuse the cache.

https://sentry.io/wego/place-services/issues/326211475/
